### PR TITLE
Fix case of file name in project file

### DIFF
--- a/Ketarin.csproj
+++ b/Ketarin.csproj
@@ -154,7 +154,7 @@
     <Compile Include="CDBurnerXP\ProgressDialog.cs">
       <SubType>Form</SubType>
     </Compile>
-    <Compile Include="CDBurnerXP\ProgressDialog.designer.cs">
+    <Compile Include="CDBurnerXP\ProgressDialog.Designer.cs">
       <DependentUpon>ProgressDialog.cs</DependentUpon>
     </Compile>
     <Compile Include="CDBurnerXP\SafeClipboard.cs" />


### PR DESCRIPTION
Renamed CDBurnerXP/ProgressDialog.designer.cs in Ketarin.csproj to match actual file name of CDBurnerXP/ProgressDialog.Designer.cs.

This is one of the simpler changes that affects Linux, but doesn't really affect Windows, since Windows file systems are generally not case sensitive.