### PR TITLE
Stop using explicit \ as directory separator

### DIFF
--- a/ApplicationJob.cs
+++ b/ApplicationJob.cs
@@ -697,7 +697,7 @@ namespace Ketarin
         [XmlElement("TargetPath")]
         public string TargetPath {
 	    get { return m_TargetPath; }
-	    set { m_targetPath = Path.FixDirectorySeparator(value); }
+	    set { m_TargetPath = PathEx.FixDirectorySeparator(value); }
        	}
 
         [XmlElement("FixedDownloadUrl")]

--- a/ApplicationJob.cs
+++ b/ApplicationJob.cs
@@ -666,7 +666,7 @@ namespace Ketarin
             {
                 if (string.IsNullOrEmpty(this.TargetPath)) return false;
 
-                return this.TargetPath.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.CurrentCulture);
+                return this.TargetPath.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal);
             }
         }
 

--- a/ApplicationJob.cs
+++ b/ApplicationJob.cs
@@ -29,6 +29,7 @@ namespace Ketarin
     public class ApplicationJob
     {
         private string m_Name;
+        private string m_TargetPath = string.Empty;
         private DateTime? m_LastUpdated;
         private UrlVariableCollection m_Variables;
         private bool m_ShareApplication;
@@ -665,7 +666,7 @@ namespace Ketarin
             {
                 if (string.IsNullOrEmpty(this.TargetPath)) return false;
 
-                return this.TargetPath.EndsWith("\\") || Directory.Exists(this.TargetPath);
+                return this.TargetPath.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.CurrentCulture);
             }
         }
 
@@ -694,7 +695,10 @@ namespace Ketarin
         }
 
         [XmlElement("TargetPath")]
-        public string TargetPath { get; set; } = string.Empty;
+        public string TargetPath {
+	    get { return m_TargetPath; }
+	    set { m_targetPath = Path.FixDirectorySeparator(value); }
+       	}
 
         [XmlElement("FixedDownloadUrl")]
         public string FixedDownloadUrl { get; set; } = string.Empty;
@@ -1481,10 +1485,10 @@ namespace Ketarin
                                 try
                                 {
                                     Uri uri1 = new Uri(this.PreviousLocation);
-                                    Uri uri2 = new Uri(Application.StartupPath + "\\");
+                                    Uri uri2 = new Uri(Application.StartupPath + Path.DirectorySeparatorChar);
 
                                     Uri relativeUri = uri2.MakeRelativeUri(uri1);
-                                    string relativePath = relativeUri.ToString().Replace("/", "\\");
+                                    string relativePath = PathEx.FixDirectorySeparator(relativeUri.ToString());
                                     // If result returns out to be not relative, no need to save
                                     if (!Path.IsPathRooted(relativePath))
                                     {

--- a/CDBurnerXP/Debug.cs
+++ b/CDBurnerXP/Debug.cs
@@ -18,7 +18,7 @@ namespace CDBurnerXP.IO
         {
             get
             {
-                string dir = Path.Combine(PathEx.TryGetFolderPath(Environment.SpecialFolder.ApplicationData), "Canneverbe Limited\\CDBurnerXP");
+                string dir = Path.Combine(PathEx.TryGetFolderPath(Environment.SpecialFolder.ApplicationData), "Canneverbe Limited", "CDBurnerXP");
                 Directory.CreateDirectory(dir);
 
                 return Path.Combine(dir, "Errors.log");

--- a/CDBurnerXP/PathEx.cs
+++ b/CDBurnerXP/PathEx.cs
@@ -189,17 +189,17 @@ namespace CDBurnerXP.IO
         {
             if (Path.IsPathRooted(file))
             {
-                file = file.Replace("/", "\\");
+		file = PathEx.FixDirectorySeparator(file);
 
                 if (file.StartsWith("\\\\"))
                 {
                     // UNC path
                     return file;
                 }
-                else if (file.StartsWith("\\"))
+                else if (file.StartsWith(Path.DirectorySeparatorChar.ToString()))
                 {
                     // If path is rooted relatively, combine with playlist file location
-                    return Path.Combine(Path.GetPathRoot(basePath), file.TrimStart('\\'));
+                    return Path.Combine(Path.GetPathRoot(basePath), file.TrimStart(Path.DirectorySeparatorChar));
                 }
                 else
                 {
@@ -273,18 +273,27 @@ namespace CDBurnerXP.IO
 
         public static string GetLastPathItem(string strPath)
         {
-            return strPath.Substring(strPath.LastIndexOf("\\") + 1);
+            return Path.GetFileName(strPath);
+        }
+
+        public static string FixDirectorySeparator(string sPath)
+        {
+            if (Path.DirectorySeparatorChar == '/')
+                return sPath.Replace('\\', Path.DirectorySeparatorChar);
+
+            return sPath.Replace('/', Path.DirectorySeparatorChar);
         }
 
         public static string QualifyPath(string sPath)
         {
-            if (sPath.EndsWith("\\"))
+            sPath = FixDirectorySeparator(sPath);
+            if (sPath.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.CurrentCulture))
             {
                 return sPath;
             }
             else
             {
-                return sPath + "\\";
+                return sPath + Path.DirectorySeparatorChar;
             }
         }
 
@@ -457,7 +466,7 @@ namespace CDBurnerXP.IO
                     key = key.OpenSubKey("Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\User Shell Folders");
                     if ((key != null) & (key.GetValue(folderName) != null))
                     {
-                        result = key.GetValue(folderName).ToString().TrimEnd('\\');
+                        result = key.GetValue(folderName).ToString().TrimEnd(Path.DirectorySeparatorChar);
                     }
                 }
                 catch (Exception)

--- a/CDBurnerXP/PathEx.cs
+++ b/CDBurnerXP/PathEx.cs
@@ -287,7 +287,7 @@ namespace CDBurnerXP.IO
         public static string QualifyPath(string sPath)
         {
             sPath = FixDirectorySeparator(sPath);
-            if (sPath.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.CurrentCulture))
+            if (sPath.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal))
             {
                 return sPath;
             }

--- a/DbManager.cs
+++ b/DbManager.cs
@@ -169,7 +169,7 @@ namespace Ketarin
                 if (m_DatabasePath == null)
                 {
                     // Only determine the path once
-                    string path = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + "\\Ketarin\\jobs.db";
+                    string path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Ketarin", "jobs.db");
                     // Is a special path set in the registry?
                     string regPath = Settings.GetValue("Ketarin", "DatabasePath", "") as string;
                     if (!string.IsNullOrEmpty(regPath) && File.Exists(regPath))


### PR DESCRIPTION
This one includes a single change that's more Linux-specific*.  Look at FixDirectorySeparator() in CDBurner/PathEx.cs.  It checks which style of directory separator is in use, and changes the opposite one to it.  This is really needed on Linux, as someone might be importing configuration from a Windows box (actually, going the other way, this will make it look nicer, although on Windows / will be seen as a directory separator, so it works without).  I can easily redo this pull request to remove that coding change if you like, since it's really only needed on Linux.

* Well, any non-Windows system that can run Mono, really.