### PR TITLE
Fix TLS connection issues

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -37,6 +37,7 @@ namespace Ketarin
         {
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
+	    System.Net.ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
 
             // Set an error handler (just a message box) for unexpected exceptions in threads
             AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;


### PR DESCRIPTION
Enabled only TLS 1.1 and TLS 1.2.

Original issue:
By default, only SSL 3.0 and TLS 1.0 are enabled for connections by .NET 4.5.x. Since most servers now reject SSL 3.0 connections, and very few use TLS 1.0, ketarin fails to download from several sites.
Change code to enable only TLS 1.1 and TLS 1.2.
TLS 1.1 should still be enabled, since it seems to still be in wide use, even though, it, too, is relatively unsafe. This should be re-visited at a later point, and only TLS 1.2 (and TLS 1.3 if it's implemented) should be enabled.