### PR TITLE
Keyboard focus lost after File->Export All

### DIFF
--- a/MainForm.cs
+++ b/MainForm.cs
@@ -1151,7 +1151,7 @@ namespace Ketarin
             using (SaveFileDialog dialog = new SaveFileDialog())
             {
                 dialog.Filter = "Application Definition|*.xml|Application Template|*.xml";
-                if (dialog.ShowDialog() != DialogResult.OK) return;
+                if (dialog.ShowDialog(this) != DialogResult.OK) return;
 
                 try
                 {
@@ -1174,7 +1174,7 @@ namespace Ketarin
             using (OpenFileDialog dialog = new OpenFileDialog())
             {
                 dialog.Filter = "XML file|*.xml";
-                if (dialog.ShowDialog() != DialogResult.OK) return;
+                if (dialog.ShowDialog(this) != DialogResult.OK) return;
 
                 try
                 {


### PR DESCRIPTION
I'm not sure if the original issue occurs on Windows (at least, not as described), but the fix ought to be used anyway.  You can get some funky things happening when you open a dialog like that without specifying the parent.  Unless .NET on Windows is implicitly setting the parent, eventually somebody's going to trigger one of those funky behaviors. :)

Modified code to pass 'this' to the ShowDialg() calls for Export ALl and
Import.

Note on Linux systems, there's a small chance this won't completely fix
the problem, since window focus is handled at the window manager level.
However, this ensures that hints are set properly, so the window manager
has a chance to do the right thing.

Note that this problem was only intermittent for me, but that's to be
expected, as the window manager might set focus back to the main program
window, when lacking anything to tell it where to set focus.