### PR TITLE
Fixed #11

### DIFF
--- a/MainForm.cs
+++ b/MainForm.cs
@@ -1038,7 +1038,14 @@ namespace Ketarin
             {
                 if (job != null)
                 {
-                    Process.Start("explorer", " /select," + job.CurrentLocation);
+                    if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+                    {
+                        Process.Start("explorer", " /select," + job.CurrentLocation);
+                    }
+                    else
+                    {
+                        Process.Start(Path.GetDirectoryName(job.CurrentLocation));
+                    }
                 }
             }
             catch (Exception)


### PR DESCRIPTION
Modified the code to check if we're running on Windows or not.  If
running on Windows, use the existing code to open up Explorer and browse
tothe folder.  Otherwise, attempt to execute the folder itself.  In most
Mono implementations, this will actually do the right thing, and bring
up the default file browser showing the folder.  It doesn't do quite the
same as Windows, but it's reasonably close.