### PR TITLE
Fix issue on Mono/Linux with random crashes

### DIFF
--- a/CDBurnerXP/SafeClipboard.cs
+++ b/CDBurnerXP/SafeClipboard.cs
@@ -17,6 +17,10 @@ namespace CDBurnerXP.IO
             {
                 return Clipboard.GetDataObject().GetDataPresent(format);
             }
+            catch (NullReferenceException)
+	    {
+		return false;
+	    }
             catch (ExternalException)
             {
                 return false;

--- a/CDBurnerXP/SafeClipboard.cs
+++ b/CDBurnerXP/SafeClipboard.cs
@@ -15,28 +15,24 @@ namespace CDBurnerXP.IO
         {
             try
             {
-                return Clipboard.GetDataObject().GetDataPresent(format);
+                IDataObject dataObject = Clipboard.GetDataObject();
+                if (dataObject != null)
+                    return dataObject.GetDataPresent(format);
             }
-            catch (NullReferenceException)
-	    {
-		return false;
-	    }
-            catch (ExternalException)
-            {
-                return false;
-            }
+            catch { }
+            return false;
         }
 
         public static object GetData(string format)
         {
             try
             {
-                return Clipboard.GetDataObject().GetData(format);
+                IDataObject dataObject = Clipboard.GetDataObject();
+                if (dataObject != null)
+                    return dataObject.GetData(format);
             }
-            catch (ExternalException)
-            {
-                return null;
-            }
+            catch { }
+	    return null;
         }
 
         public static bool SetData(object value, bool copy)

--- a/CDBurnerXP/SafeClipboard.cs
+++ b/CDBurnerXP/SafeClipboard.cs
@@ -32,7 +32,7 @@ namespace CDBurnerXP.IO
                     return dataObject.GetData(format);
             }
             catch { }
-	    return null;
+            return null;
         }
 
         public static bool SetData(object value, bool copy)


### PR DESCRIPTION
Clipboard.GetDataObject() returns null sometimes on Linux.  Modified code to check for null.  Also modified code to catch all exceptions in SafeClipboard.IsDataPresent and SafeClipboard.GetData.  This prevents the methods from passing exceptions to calling code, which might not expect to see exceptions.

Note: I noticed a couple of different methods for catching all exceptions in the codebase.  If this is not your preferred method, let me know, and I'll change it.